### PR TITLE
Add 'text' dependence to 'csh-eval-db-init' cabal target.

### DIFF
--- a/csh-eval.cabal
+++ b/csh-eval.cabal
@@ -38,6 +38,7 @@ executable csh-eval-db-init
   hs-source-dirs:      db
   default-language:    Haskell2010
   build-depends:       base >= 4.8 && < 4.9
+                      ,text
                       ,shelly
 
 library


### PR DESCRIPTION
Whoops.
