### PR TITLE
Adding basic LDAP convenience functions

### DIFF
--- a/csh-eval.cabal
+++ b/csh-eval.cabal
@@ -43,17 +43,20 @@ executable csh-eval-db-init
 
 library
     exposed-modules:     CSH.Eval.Routes
-                        ,CSH.Eval.DB.ContextPool
-                        ,CSH.Eval.DB.Statements
+                       , CSH.Eval.DB.ContextPool
+                       , CSH.Eval.DB.Statements
+                       , CSH.LDAP
     hs-source-dirs:      src
     build-depends:       base >=4.8 && <4.9
                  ,       safe
                  ,       servant
                  ,       servant-server
                  ,       resource-pool
+                 ,       text
                  ,       time
                  ,       HDBC
                  ,       HDBC-postgresql
+                 ,       ldap-client
     default-language:    Haskell2010
 
 

--- a/src/CSH/LDAP.hs
+++ b/src/CSH/LDAP.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE OverloadedStrings #-}
+module CSH.LDAP
+( userBaseTxt
+, appBaseTxt
+, groupBaseTxt
+, committeeBaseTxt
+, appDn
+, userDn
+, withCSH
+) where
+
+import Ldap.Client
+import Data.Text as T
+
+-- | Generates a base given an Org Unit (ou) name.
+cshBaseTxt :: T.Text -- ^ ou name
+           -> T.Text
+cshBaseTxt str = T.concat ["ou=", str, ",dc=csh,dc=rit,dc=edu"]
+
+-- | Distinct name for users
+userBaseTxt :: T.Text
+userBaseTxt = cshBaseTxt "users"
+
+-- | Distinct name for apps
+appBaseTxt :: T.Text
+appBaseTxt = cshBaseTxt "apps"
+
+-- | Distinct name for groups
+groupBaseTxt :: T.Text
+groupBaseTxt = cshBaseTxt "groups"
+
+-- | Distinct name for committees
+committeeBaseTxt :: T.Text
+committeeBaseTxt = cshBaseTxt "committees"
+
+-- | Creates a Dn based on the name of the application
+appDn :: Text -- ^ Common name of app
+      -> Dn
+appDn app = Dn $ T.concat ["cn=", app, ",", appBaseTxt]
+
+-- | Creates a Dn based on the uid of the user
+userDn :: Text -- ^ uid of user
+       -> Dn
+userDn user = Dn $ T.concat ["uid=", user, ",", userBaseTxt]
+
+-- | Wraps LDAP transactions.
+withCSH :: (Ldap -> IO a) -> IO (Either LdapError a)
+withCSH = with (Secure "ldap.csh.rit.edu") 636


### PR DESCRIPTION
We should be reading the values of the convience methods from a config,
as they are subject to change. In the meantime, this should make LDAP
development significantly less painful.
