### PR TITLE
Added remote dependencies to evalLayout

### DIFF
--- a/frontend/index.hamlet
+++ b/frontend/index.hamlet
@@ -1,2 +1,1 @@
-<nav .navbar .navbar-inverse>
-  <div .container>
+<h1>Welcome to the CSH Evaluations Database, written in <strike>perl</strike> <strike>python</strike> haskell!

--- a/frontend/templates/base.hamlet
+++ b/frontend/templates/base.hamlet
@@ -5,4 +5,9 @@ $doctype 5
     <meta charset=utf-8>
     ^{pageHead pc}
   <body>
-    ^{pageBody pc}
+    <nav .navbar .navbar-inverse>
+      <div .container>
+    <div #content>
+      ^{pageBody pc}
+    <div #footer>
+      <div .container>

--- a/src/CSH/Eval/Frontend.hs
+++ b/src/CSH/Eval/Frontend.hs
@@ -38,6 +38,9 @@ evalLayout :: Widget -> Handler Html
 evalLayout widget = do
     pc <- widgetToPageContent $ do
         widget
+        addStylesheetRemote "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"
+        addStylesheetRemote "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"
+        addScriptRemote "https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"
         toWidget $(luciusFile "frontend/static/csh-bootstrap.min.css")
         toWidget $(luciusFile "frontend/static/csh-eval.lucius")
     withUrlRenderer $(hamletFile "frontend/templates/base.hamlet")


### PR DESCRIPTION
I was going to use type-safe urls, but we are only using these urls in one place. If we need to use them in multiple layouts or other widgets, we can create a widget called something like `remoteDependenciesWidget` that we can include in both of them. 
