### PR TITLE
Restructure widgets framework

### DIFF
--- a/frontend/templates/index.hamlet
+++ b/frontend/templates/index.hamlet
@@ -1,2 +1,2 @@
 <div .row>
-  ^{widgetPanel 3 "<strong>Example Title</strong>" "<p>Welcome to the CSH Evaluations Database, written in <strike>perl</strike> <strike>python</strike> haskell!</p>"}
+  ^{widgetPanelText 3 "<strong>Example Title</strong>" "<p>Welcome to the CSH Evaluations Database, written in <strike>perl</strike> <strike>python</strike> haskell!</p>"}

--- a/frontend/templates/widgets/panelText.hamlet
+++ b/frontend/templates/widgets/panelText.hamlet
@@ -2,6 +2,6 @@
   <div .panel .panel-default .center>
     <div .panel-heading>
       <div .panel-title>
-        ^{title}
+        #{preEscapedText title}
     <div .panel-body>
-      ^{body}
+      #{preEscapedText body}

--- a/src/CSH/Eval/Frontend.hs
+++ b/src/CSH/Eval/Frontend.hs
@@ -81,8 +81,18 @@ toText :: Integer -> T.Text
 toText = T.pack . show
 
 -- | A basic widget for a panel
-widgetPanel :: Integer -> T.Text -> T.Text -> Widget
+-- The first argument is the horizontal size of the panel
+-- The second argument is the widget for the title of the panel
+-- The third argument is the widget for the body of the panel
+widgetPanel :: Integer -> Widget -> Widget -> Widget
 widgetPanel mdsize title body = $(whamletFile "frontend/templates/widgets/panel.hamlet")
+
+-- | A basic widget for a panel that takes text as arguments instead of widgets
+-- The first argument is the horizontal size of the panel
+-- The second argument is the html for the title of the panel
+-- The third argument is the html for the body of the panel
+widgetPanelText :: Integer -> T.Text -> T.Text -> Widget
+widgetPanelText mdsize title body = $(whamletFile "frontend/templates/widgets/panelText.hamlet")
 
 -- * Pages
 

--- a/src/CSH/Eval/Frontend.hs
+++ b/src/CSH/Eval/Frontend.hs
@@ -81,17 +81,17 @@ toText :: Integer -> T.Text
 toText = T.pack . show
 
 -- | A basic widget for a panel
--- The first argument is the horizontal size of the panel
--- The second argument is the widget for the title of the panel
--- The third argument is the widget for the body of the panel
-widgetPanel :: Integer -> Widget -> Widget -> Widget
+widgetPanel :: Integer -- horizontal size of the panel
+            -> Widget  -- widget for the title of the panel
+            -> Widget  -- widget for the body of the panel
+            -> Widget
 widgetPanel mdsize title body = $(whamletFile "frontend/templates/widgets/panel.hamlet")
 
 -- | A basic widget for a panel that takes text as arguments instead of widgets
--- The first argument is the horizontal size of the panel
--- The second argument is the html for the title of the panel
--- The third argument is the html for the body of the panel
-widgetPanelText :: Integer -> T.Text -> T.Text -> Widget
+widgetPanelText :: Integer -- horizontal size of the panel
+                -> T.Text  -- html for the title of the panel
+                -> T.Text  -- html for the body of the panel
+                -> Widget
 widgetPanelText mdsize title body = $(whamletFile "frontend/templates/widgets/panelText.hamlet")
 
 -- * Pages


### PR DESCRIPTION
Since we can't call whamlet from inside another template, we need to settle for having a text version of a widget for simple situations and a widget version for more complex ones, where the widget version has to be constructed inside of a Haskell file instead of in a template.
