### PR TITLE
Breaking out the Frontend.hs file into bite-size chunks

### DIFF
--- a/config/routes
+++ b/config/routes
@@ -1,0 +1,12 @@
+-- Route definitions for the Evaluations Database frontend
+-- This is where you add the routes for new HTML pages
+-- The EvalAPI is defined as a subsite of this website, under the /api route.
+-- Static files are placed under the /static route, also a subsite,
+-- facilitated by the yesod-static package.
+/                           HomeR                    GET
+/evals/membership/overview  EvalsMembershipOverviewR GET
+/api                        EvalSubsiteR WaiSubsite  getEvalAPI
+/static                     StaticR Static           getStatic
+/projects                   ProjectsR                GET
+!/projects/create           CreateProjectR           GET
+/projects/#Int              ProjectR                 GET

--- a/config/routes
+++ b/config/routes
@@ -3,10 +3,29 @@
 -- The EvalAPI is defined as a subsite of this website, under the /api route.
 -- Static files are placed under the /static route, also a subsite,
 -- facilitated by the yesod-static package.
-/                           HomeR                    GET
-/evals/membership/overview  EvalsMembershipOverviewR GET
+
+-- Before you add a new route here, check out the `frontend/README.md` file
+-- for information on the full process of adding pages.
+
+-- An example of a basic route definition is
+--      /route/to/page NameOfRouteR GET
+-- For more information on the syntax of route definitions, see the yesod book
+-- chapter on routing (http://www.yesodweb.com/book/routing-and-handlers)
+
+-- Sort your routes underneath the header for the file that the routes
+-- corresponding headers will go, for clarity.
+
+-- Subsites
 /api                        EvalSubsiteR WaiSubsite  getEvalAPI
 /static                     StaticR Static           getStatic
+
+-- Home.hs
+/                           HomeR                    GET
+
+-- Evals.hs
+/evals/membership/overview  EvalsMembershipOverviewR GET
+
+-- Projects.hs
 /projects                   ProjectsR                GET
 !/projects/create           CreateProjectR           GET
 /projects/#Int              ProjectR                 GET

--- a/csh-eval.cabal
+++ b/csh-eval.cabal
@@ -17,24 +17,24 @@ cabal-version:         >=1.10
 
 executable csh-eval
   main-is:             Main.hs
-  build-depends:        base                >=4.7      && <4.9
-                       ,bytestring          >=0.10.4   && <0.10.7
-                       ,safe                >=0.3.9    && <0.3.10
-                       ,servant             >= 0.4     && <0.5
-                       ,servant-server      >= 0.4     && <0.5
-                       ,csh-eval
-                       ,warp                >=3.0.13   && <3.0.14
-                       ,time                >=1.4.2    && <1.5.1
-                       ,hasql               >=0.7.3    && <0.7.4
-                       ,hasql-postgres      >=0.10.3   && <0.10.4
-                       ,wai                 >=3.0.2    && <3.0.4
-                       ,yesod               >=1.4.1    && <1.4.2
-                       ,yesod-static        >=1.2.0    && <1.6.0
-                       ,shakespeare         >=2.0.5    && <2.0.6
-                       ,uuid                >=1.3.10   && <1.3.11
-                       ,text                >=1.2      && <1.3
-                       ,blaze-markup        >=0.7      && <0.8
-                       ,yesod-markdown      >=0.10.0
+  build-depends:       base                 >=4.7      && <4.9
+                      ,bytestring           >=0.10.4   && <0.10.7
+                      ,safe                 >=0.3.9    && <0.3.10
+                      ,servant              >=0.4      && <0.5
+                      ,servant-server       >=0.4      && <0.5
+                      ,csh-eval
+                      ,warp                 >=3.0.13   && <3.0.14
+                      ,time                 >=1.4.2    && <1.5.1
+                      ,hasql                >=0.7.3    && <0.7.4
+                      ,hasql-postgres       >=0.10.3   && <0.10.4
+                      ,wai                  >=3.0.2    && <3.0.4
+                      ,yesod                >=1.4.1    && <1.4.2
+                      ,yesod-static         >=1.2.0    && <1.6.0
+                      ,shakespeare          >=2.0.5    && <2.0.6
+                      ,uuid                 >=1.3.10   && <1.3.11
+                      ,text                 >=1.2      && <1.3
+                      ,blaze-markup         >=0.7      && <0.8
+                      ,yesod-markdown       >=0.10.0
   hs-source-dirs:      src
   default-extensions:  OverloadedStrings
   default-language:    Haskell2010
@@ -44,7 +44,7 @@ executable csh-eval-db-init
   hs-source-dirs:      db
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings
-  build-depends:       base                 >= 4.7     && < 4.9
+  build-depends:       base                 >=4.7      && <4.9
                       ,hasql                >=0.7.3    && <0.7.4
                       ,hasql-postgres       >=0.10.3   && <0.10.4
                       ,bytestring           >=0.10.4   && <0.10.7
@@ -69,13 +69,13 @@ library
   build-depends:       base                 >=4.7      && <4.9
                       ,bytestring           >=0.10.4   && <0.10.7
                       ,safe                 >=0.3.9    && <0.3.10
-                      ,servant              >= 0.4     && <0.5
-                      ,servant-server       >= 0.4     && <0.5
+                      ,servant              >=0.4      && <0.5
+                      ,servant-server       >=0.4      && <0.5
                       ,text                 >=1.2.0.6  && <1.3
                       ,time                 >=1.4.2    && <1.5.1
                       ,hasql                >=0.7.3    && <0.7.4
                       ,hasql-postgres       >=0.10.3   && <0.10.4
-                      ,ldap-client          >= 0.1.0   && <0.1.1
+                      ,ldap-client          >=0.1.0    && <0.1.1
                       ,wai                  >=3.0.2    && <3.0.4
                       ,yesod                >=1.4.1    && <1.4.2
                       ,yesod-static         >=1.2.0    && <1.6.0

--- a/csh-eval.cabal
+++ b/csh-eval.cabal
@@ -57,6 +57,8 @@ library
                       ,CSH.Eval.DB.Statements
                       ,CSH.Eval.Frontend
                       ,CSH.Eval.Frontend.Data
+                      ,CSH.Eval.Frontend.Projects
+                      ,CSH.Eval.Frontend.Widgets
                       ,CSH.Eval.Routes
                       ,CSH.Eval.Cacheable
                       ,CSH.Eval.Model

--- a/csh-eval.cabal
+++ b/csh-eval.cabal
@@ -58,6 +58,8 @@ library
                       ,CSH.Eval.Frontend
                       ,CSH.Eval.Frontend.Data
                       ,CSH.Eval.Frontend.Projects
+                      ,CSH.Eval.Frontend.Evals
+                      ,CSH.Eval.Frontend.Home
                       ,CSH.Eval.Frontend.Widgets
                       ,CSH.Eval.Routes
                       ,CSH.Eval.Cacheable

--- a/csh-eval.cabal
+++ b/csh-eval.cabal
@@ -56,6 +56,7 @@ library
   exposed-modules:     CSH.Eval.DB.Schema
                       ,CSH.Eval.DB.Statements
                       ,CSH.Eval.Frontend
+                      ,CSH.Eval.Frontend.Data
                       ,CSH.Eval.Routes
                       ,CSH.Eval.Cacheable
                       ,CSH.Eval.Model

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,8 +12,8 @@ changing the data that is needed for a page, no Haskell changes are needed.
 ## Changing a page
 
 All of the pages in the frontend for the evaluations database are written in
-the shakespearean templating language. Hamlet is the HTML template language for
-shakespeare. A good introduction to the language is in the [Yesod Book chapter
+the Shakespearean templating language. Hamlet is the HTML template language for
+Shakespeare. A good introduction to the language is in the [Yesod Book chapter
 on it][shakespeare]. 
 
 If you are just changing layout or styling, you won't have to touch any
@@ -31,28 +31,37 @@ have to be added very often.
     named well and placed under it's proper category (`voting/`, `packet/`,
     `evals/`, etc.).
 
-2.  Add the route to your new page in the `src/CSH/Eval/Frontend.hs` file under
-    the route definitions. The layout of the route definition is
-
+2.  Add the route to your new page in the `config/routes` file. The layout of
+    the route definition is
+    ```
         /route/to/page NameOfRouteR GET
-
+    ```
     The name of the route should have something do to with the route itself, 
     since all pages have names, and we want page names to be unambiguous. 
 
-    If the route to the page needs arguments, see the [Yesod Routing][routing] 
+    If the route to the page needs arguments, see the [Yesod Routing][routing]
     page for more details.
 
 3.  Add the handler for the page at the bottom of the `src/CSH/Eval/Frontend.hs`
     file. The handler is defined to be named
+3.  Add the handler to the relevant page definitions file under 
+    `src/CSH/Eval/Frontend/`. This would be something like `Evals.hs` or 
+    `Projects.hs`. The name of the file doesn't matter as long as it is clear
+    what handlers should go in the file, it is just a logical separation for
+    the developers.
+
+    The handler is a function that, in it's simplest form, should be defined
+    as
     ``` Haskell
         getNameOfRouteR :: Handler Html
+        getNameOfRouteR = defaultLayout $(whamletFile "frontend/templates/folder/folder/file.hamlet")
     ```
     for the above route example. 
 
-    The handler should be defined as
-    ```Haskell
-        getNameOfRouteR = defaultLayout $(whamletFile "frontend/templates/folder/folder/file.hamlet")
-    ```
+    You can also have arguments passed to this function that can be accessed
+    from within the hamlet file, see the shakespeare docs for more information
+    on how to define a route so that it takes arguments.
+
 4.  Make your page. See the [Yesod Shakespeare Templates][shakespeare] page for
     details on making pages using the hamlet templating language.
 
@@ -75,8 +84,8 @@ your data in hand!
 
 We provide a set of reusable widgets to be used our pages, to cut down on the
 volume of HTML that needs to be written, make everything cleaner looking,
-and reduce errors. Check out the Haddock for `CSH.Eval.Frontend` for an
-up-to-date listing of all of the widgets we provide. 
+and reduce errors. Check out the Haddock for `CSH.Eval.Frontend.Widgets` for
+an up-to-date listing of all of the widgets we provide. 
 
 It is simple to embed a widget into your page -
 ```Haskell
@@ -91,7 +100,7 @@ Adding a widget is similar to adding a page, except you don't specify a route.
 
 1.  Add a hamlet page under `frontend/templates/widgets`. 
 
-2.  Add a widget function.
+2.  Add a widget function in the `src/CSH/Eval/Frontend/Widgets.hs` file.
     ``` Haskell
         widgetName :: Widget
         widgetName = $(whamletFile "frontend/templates/widgets/name.hamlet")

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -48,6 +48,10 @@ have to be added very often.
     what handlers should go in the file, it is just a logical separation for
     the developers.
 
+    If you do add a handlers file, you will need to add the module name under
+    the `csh-eval.cabal` file and import it into the `src/CSH/Eval/Frontend.hs`
+    file. Use the `src/CSH/Eval/Frontend/Home.hs` file as a template.
+
     The handler is a function that, in it's simplest form, should be defined
     as
     ``` Haskell

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -42,8 +42,6 @@ have to be added very often.
     If the route to the page needs arguments, see the [Yesod Routing][routing]
     page for more details.
 
-3.  Add the handler for the page at the bottom of the `src/CSH/Eval/Frontend.hs`
-    file. The handler is defined to be named
 3.  Add the handler to the relevant page definitions file under 
     `src/CSH/Eval/Frontend/`. This would be something like `Evals.hs` or 
     `Projects.hs`. The name of the file doesn't matter as long as it is clear

--- a/src/CSH/Eval/Frontend.hs
+++ b/src/CSH/Eval/Frontend.hs
@@ -22,7 +22,8 @@ module CSH.Eval.Frontend
 
 import CSH.Eval.Frontend.Data
 import CSH.Eval.Frontend.Projects
-import CSH.Evla.Frontend.Evals
+import CSH.Eval.Frontend.Evals
+import CSH.Eval.Frontend.Home
 import Text.Hamlet (hamletFile)
 import Text.Lucius (luciusFile)
 import Yesod

--- a/src/CSH/Eval/Frontend.hs
+++ b/src/CSH/Eval/Frontend.hs
@@ -18,21 +18,15 @@ Defines the web application layer of Evals
 
 module CSH.Eval.Frontend 
 ( evalFrontend
- ,widgetPanel
- ,widgetPanelOffset
- ,widgetPanelText
 ) where
 
-import qualified Data.Text as T
-
 import CSH.Eval.Frontend.Data
+import CSH.Eval.Frontend.Projects
+import CSH.Eval.Frontend.Widgets
 import Text.Hamlet (hamletFile)
 import Text.Lucius (luciusFile)
-import Text.Blaze  (preEscapedText)
 import Yesod
 import Yesod.Static
-import Yesod.Markdown
-import Data.List (unfoldr, find)
 
 mkYesodDispatch "EvalFrontend" resourcesEvalFrontend
 
@@ -41,30 +35,6 @@ evalFrontend :: IO Application
 evalFrontend = do
     s <- static "frontend/static"
     toWaiApp $ EvalFrontend s
-
--- * Widgets
-
--- | A helper function to convert integers to text, to make templates that use
--- Integer arguments more readable.
-toText :: Integer -> T.Text
-toText = T.pack . show
-
--- | A basic widget for a panel
-widgetPanel :: Integer -- horizontal size of the panel
-            -> Widget  -- widget for the title of the panel
-            -> Widget  -- widget for the body of the panel
-            -> Widget
-widgetPanel mdsize title body = widgetPanelOffset mdsize 0 title body
-
-widgetPanelOffset :: Integer -> Integer -> Widget -> Widget -> Widget
-widgetPanelOffset mdsize mdoffset title body = $(whamletFile "frontend/templates/widgets/panel.hamlet")
-
--- | A basic widget for a panel that takes text as arguments instead of widgets
-widgetPanelText :: Integer -- horizontal size of the panel
-                -> T.Text  -- html for the title of the panel
-                -> T.Text  -- html for the body of the panel
-                -> Widget
-widgetPanelText mdsize title body = $(whamletFile "frontend/templates/widgets/panelText.hamlet")
 
 -- * Pages
 
@@ -75,55 +45,3 @@ getHomeR = defaultLayout $(whamletFile "frontend/templates/index.hamlet")
 -- | The page for the Overiview of Membership Evaluations
 getEvalsMembershipOverviewR :: Handler Html
 getEvalsMembershipOverviewR = defaultLayout $(whamletFile "frontend/templates/evals/membership/overview.hamlet")
-
-projects :: [(T.Text, T.Text, T.Text, T.Text, Int)]
-projects = (take 100 . cycle)
-    [("Harlan Haskins", "Punctual.swift", "## Punctual.swift\n\nPunctual.swift is a set of extensions to `NSDate`, `Int`, `NSTimeInterval`, `NSCalendar`, and `NSDateComponents`.\n```rust\n1.day.until(NSDate())\n```", "In Progress", 4)
-    ,("DuWayne Theroc-Johnson", "Bloodline", "# Bloodline\nA 1-900 hotline for blood deliveries. Uses the `MEAN` stack -- `MongoDB`, `Express.js`, `Angularjs` and `Node.js`. That means this project is **truly** web scale.\n```javascript\nfunction thing() {\n  console.log('hello');\n}\n```", "Completed", 5)
-    ,("Matt Gambogi", "tyle", "TYped Language Evaluator", "In Progress", 6)
-    ] 
-
-projectsCSS = toWidget $(luciusFile "frontend/templates/projects/projects.lucius")
-
--- | The page for a overview of CSH projects.
-getProjectsR :: Handler Html
-getProjectsR = defaultLayout $ do
-    projectsCSS
-    $(whamletFile "frontend/templates/projects/index.hamlet")
-    where panel member name description status = widgetPanel 6 (title name member status) (contentPanel description)
-
-title name member status = [whamlet| 
-  <strong> 
-      #{name} 
-  <span .project-status>
-      #{status}
-  <br />
-  <span .project-author>
-      by 
-      <strong>
-          #{member}
-|]
-
--- TODO handle parse error correctly
-contentPanel :: T.Text -> Widget
-contentPanel description = [whamlet|
-  <div .project-content>
-      ^{either (error . show) id $ markdownToHtml $ Markdown description}
-|]
-
-getProjectR id = defaultLayout $ do
-    projectsCSS
-    panel
-    where fromID = find (\(_, _, _, _, id') -> id == id') projects
-          panel = case fromID of
-                    Nothing -> notFound
-                    Just (member, name, description, status, _) -> widgetPanelOffset 8 2 (title name member status) (contentPanel description)
-
-committees :: [T.Text]
-committees = ["Evaluations", "Financial", "OpComm", "House History", "House Improvements", "Research and Development", "Social", "Chairman"]
-
-projectForm = $(whamletFile "frontend/templates/projects/create.hamlet")
-
-getCreateProjectR = defaultLayout $ do
-    projectsCSS
-    widgetPanelOffset 8 2 [whamlet|New Project|] projectForm

--- a/src/CSH/Eval/Frontend.hs
+++ b/src/CSH/Eval/Frontend.hs
@@ -25,7 +25,7 @@ module CSH.Eval.Frontend
 
 import qualified Data.Text as T
 
-import CSH.Eval.Routes (evalAPI)
+import CSH.Eval.Frontend.Data
 import Text.Hamlet (hamletFile)
 import Text.Lucius (luciusFile)
 import Text.Blaze  (preEscapedText)
@@ -34,55 +34,13 @@ import Yesod.Static
 import Yesod.Markdown
 import Data.List (unfoldr, find)
 
--- Declaration of location of static files
-staticFiles "frontend/static"
-
--- | datatype for Yesod
-data EvalFrontend = EvalFrontend
-                  { getStatic :: Static
-                  }
-
--- Route definition for the Evaluations Database Website
--- This is where you add new HTML pages
--- The EvalAPI is defined as a subsite of this website, under the /api route.
--- Static files are placed under the /static route, also as a subsite,
--- facilitated by the yesod-static package.
-mkYesod "EvalFrontend" [parseRoutes|
-/                           HomeR                    GET
-/evals/membership/overview  EvalsMembershipOverviewR GET
-/api                        EvalSubsiteR WaiSubsite  getEvalAPI
-/static                     StaticR Static           getStatic
-/projects                   ProjectsR                GET
-!/projects/create           CreateProjectR           GET
-/projects/#Int              ProjectR                 GET
-|]
-
--- | The basic layout for every CSH Eval page
-evalLayout :: Widget -> Handler Html
-evalLayout widget = do
-    pc <- widgetToPageContent $ do
-        widget
-        addStylesheetRemote "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"
-        addStylesheetRemote "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"
-        addScriptRemote "https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"
-        addStylesheet $ StaticR csh_bootstrap_min_css
-        addStylesheet $ StaticR syntax_css
-        toWidget $(luciusFile "frontend/templates/csh-eval.lucius")
-    withUrlRenderer $(hamletFile "frontend/templates/base.hamlet")
-
--- | The Yesod instance for the EvalFrontend
-instance Yesod EvalFrontend where
-    defaultLayout = evalLayout
+mkYesodDispatch "EvalFrontend" resourcesEvalFrontend
 
 -- | Defines the WAI Application for the eval Yesod app
 evalFrontend :: IO Application
 evalFrontend = do
     s <- static "frontend/static"
     toWaiApp $ EvalFrontend s
-
--- | A Yesod subsite for the evalAPI defined using servant in "CSH.Eval.Routes"
-getEvalAPI :: EvalFrontend -> WaiSubsite
-getEvalAPI _ = WaiSubsite evalAPI
 
 -- * Widgets
 

--- a/src/CSH/Eval/Frontend/Data.hs
+++ b/src/CSH/Eval/Frontend/Data.hs
@@ -1,0 +1,70 @@
+{-|
+Module      : CSH.Eval.Frontend
+Description : The top level routing of calls to the web viewer
+Copyright   : Stephen Demos, Matt Gambogi, Travis Whitaker, Computer Science House 2015
+License     : MIT
+Maintainer  : pvals@csh.rit.edu
+Stability   : Provisional
+Portability : POSIX
+
+Defines the web application layer of Evals
+-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE ViewPatterns      #-}
+
+module CSH.Eval.Frontend.Data where
+
+import CSH.Eval.Routes (evalAPI)
+import Text.Hamlet (hamletFile)
+import Text.Lucius (luciusFile)
+import Yesod
+import Yesod.Static
+
+-- Declaration of location of static files
+staticFiles "frontend/static"
+
+-- | datatype for Yesod
+data EvalFrontend = EvalFrontend
+                  { getStatic :: Static
+                  }
+
+-- Route definition for the Evaluations Database Website
+-- This is where you add new HTML pages
+-- The EvalAPI is defined as a subsite of this website, under the /api route.
+-- Static files are placed under the /static route, also as a subsite,
+-- facilitated by the yesod-static package.
+mkYesodData "EvalFrontend" [parseRoutes|
+/                           HomeR                    GET
+/evals/membership/overview  EvalsMembershipOverviewR GET
+/api                        EvalSubsiteR WaiSubsite  getEvalAPI
+/static                     StaticR Static           getStatic
+/projects                   ProjectsR                GET
+!/projects/create           CreateProjectR           GET
+/projects/#Int              ProjectR                 GET
+|]
+
+-- | A Yesod subsite for the evalAPI defined using servant in "CSH.Eval.Routes"
+getEvalAPI :: EvalFrontend -> WaiSubsite
+getEvalAPI _ = WaiSubsite evalAPI
+
+-- | The basic layout for every CSH Eval page
+evalLayout :: Widget -> Handler Html
+evalLayout widget = do
+    pc <- widgetToPageContent $ do
+        widget
+        addStylesheetRemote "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"
+        addStylesheetRemote "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"
+        addScriptRemote "https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"
+        addStylesheet $ StaticR csh_bootstrap_min_css
+        addStylesheet $ StaticR syntax_css
+        toWidget $(luciusFile "frontend/templates/csh-eval.lucius")
+    withUrlRenderer $(hamletFile "frontend/templates/base.hamlet")
+
+-- | The Yesod instance for the EvalFrontend
+instance Yesod EvalFrontend where
+    defaultLayout = evalLayout
+

--- a/src/CSH/Eval/Frontend/Data.hs
+++ b/src/CSH/Eval/Frontend/Data.hs
@@ -1,6 +1,6 @@
 {-|
-Module      : CSH.Eval.Frontend
-Description : The top level routing of calls to the web viewer
+Module      : CSH.Eval.Frontend.Data
+Description : Yesod data declarations for the EvalFrontend site
 Copyright   : Stephen Demos, Matt Gambogi, Travis Whitaker, Computer Science House 2015
 License     : MIT
 Maintainer  : pvals@csh.rit.edu

--- a/src/CSH/Eval/Frontend/Data.hs
+++ b/src/CSH/Eval/Frontend/Data.hs
@@ -67,4 +67,3 @@ evalLayout widget = do
 -- | The Yesod instance for the EvalFrontend
 instance Yesod EvalFrontend where
     defaultLayout = evalLayout
-

--- a/src/CSH/Eval/Frontend/Data.hs
+++ b/src/CSH/Eval/Frontend/Data.hs
@@ -32,20 +32,9 @@ data EvalFrontend = EvalFrontend
                   { getStatic :: Static
                   }
 
--- Route definition for the Evaluations Database Website
--- This is where you add new HTML pages
--- The EvalAPI is defined as a subsite of this website, under the /api route.
--- Static files are placed under the /static route, also as a subsite,
--- facilitated by the yesod-static package.
-mkYesodData "EvalFrontend" [parseRoutes|
-/                           HomeR                    GET
-/evals/membership/overview  EvalsMembershipOverviewR GET
-/api                        EvalSubsiteR WaiSubsite  getEvalAPI
-/static                     StaticR Static           getStatic
-/projects                   ProjectsR                GET
-!/projects/create           CreateProjectR           GET
-/projects/#Int              ProjectR                 GET
-|]
+-- This makes the datatypes for the evaluations frontend, for use by
+-- page hanlders in different files without having recursive importing.
+mkYesodData "EvalFrontend" $(parseRoutesFile "config/routes")
 
 -- | A Yesod subsite for the evalAPI defined using servant in "CSH.Eval.Routes"
 getEvalAPI :: EvalFrontend -> WaiSubsite

--- a/src/CSH/Eval/Frontend/Evals.hs
+++ b/src/CSH/Eval/Frontend/Evals.hs
@@ -1,0 +1,33 @@
+{-|
+Module      : CSH.Eval.Frontend.Evals
+Description : Evaluations related route handlers
+Copyright   : Stephen Demos, Matt Gambogi, Travis Whitaker, Computer Science House 2015
+License     : MIT
+Maintainer  : pvals@csh.rit.edu
+Stability   : Provisional
+Portability : POSIX
+
+Route handlers for the various Evaluations pages, such as Freshmen evals and membership evals
+-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE ViewPatterns      #-}
+
+module CSH.Eval.Frontend.Evals
+( getEvalsMembershipOverviewR
+) where
+
+import qualified Data.Text as T
+
+import CSH.Eval.Frontend.Data
+import CSH.Eval.Frontend.Widgets
+import Text.Hamlet (hamletFile)
+import Text.Lucius (luciusFile)
+import Yesod
+
+-- | The page for the Overiview of Membership Evaluations
+getEvalsMembershipOverviewR :: Handler Html
+getEvalsMembershipOverviewR = defaultLayout $(whamletFile "frontend/templates/evals/membership/overview.hamlet")

--- a/src/CSH/Eval/Frontend/Home.hs
+++ b/src/CSH/Eval/Frontend/Home.hs
@@ -14,7 +14,7 @@ Portability : POSIX
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE ViewPatterns      #-}
 
-module CSH.Eval.Frontend.Projects
+module CSH.Eval.Frontend.Home
 ( getHomeR
 ) where
 

--- a/src/CSH/Eval/Frontend/Home.hs
+++ b/src/CSH/Eval/Frontend/Home.hs
@@ -1,13 +1,11 @@
 {-|
-Module      : CSH.Eval.Frontend
-Description : The top level routing of calls to the web viewer
+Module      : CSH.Eval.Frontend.Home
+Description : The route handler for the home page
 Copyright   : Stephen Demos, Matt Gambogi, Travis Whitaker, Computer Science House 2015
 License     : MIT
 Maintainer  : pvals@csh.rit.edu
 Stability   : Provisional
 Portability : POSIX
-
-Defines the web application layer of Evals
 -}
 {-# LANGUAGE QuasiQuotes       #-}
 {-# LANGUAGE TypeFamilies      #-}
@@ -16,22 +14,18 @@ Defines the web application layer of Evals
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE ViewPatterns      #-}
 
-module CSH.Eval.Frontend 
-( evalFrontend
+module CSH.Eval.Frontend.Projects
+( getHomeR
 ) where
 
+import qualified Data.Text as T
+
 import CSH.Eval.Frontend.Data
-import CSH.Eval.Frontend.Projects
-import CSH.Evla.Frontend.Evals
+import CSH.Eval.Frontend.Widgets
 import Text.Hamlet (hamletFile)
 import Text.Lucius (luciusFile)
 import Yesod
-import Yesod.Static
 
-mkYesodDispatch "EvalFrontend" resourcesEvalFrontend
-
--- | Defines the WAI Application for the eval Yesod app
-evalFrontend :: IO Application
-evalFrontend = do
-    s <- static "frontend/static"
-    toWaiApp $ EvalFrontend s
+-- | An example Html handler for the frontend
+getHomeR :: Handler Html
+getHomeR = defaultLayout $(whamletFile "frontend/templates/index.hamlet")

--- a/src/CSH/Eval/Frontend/Home.hs
+++ b/src/CSH/Eval/Frontend/Home.hs
@@ -26,6 +26,6 @@ import Text.Hamlet (hamletFile)
 import Text.Lucius (luciusFile)
 import Yesod
 
--- | An example Html handler for the frontend
+-- | The handler for the Evaluations Database index page
 getHomeR :: Handler Html
 getHomeR = defaultLayout $(whamletFile "frontend/templates/index.hamlet")

--- a/src/CSH/Eval/Frontend/Projects.hs
+++ b/src/CSH/Eval/Frontend/Projects.hs
@@ -1,0 +1,85 @@
+{-|
+Module      : CSH.Eval.Frontend.Projects
+Description : Project related route handlers
+Copyright   : Stephen Demos, Matt Gambogi, Travis Whitaker, Computer Science House 2015
+License     : MIT
+Maintainer  : pvals@csh.rit.edu
+Stability   : Provisional
+Portability : POSIX
+
+Defines the web application layer of Evals
+-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE ViewPatterns      #-}
+
+module CSH.Eval.Frontend.Projects
+( getProjectR
+, getProjectsR
+, getCreateProjectR
+) where
+
+import qualified Data.Text as T
+
+import CSH.Eval.Frontend.Data
+import CSH.Eval.Frontend.Widgets
+import Text.Hamlet (hamletFile)
+import Text.Lucius (luciusFile)
+import Yesod
+import Yesod.Markdown
+import Data.List (unfoldr, find)
+
+projects :: [(T.Text, T.Text, T.Text, T.Text, Int)]
+projects = (take 100 . cycle)
+    [("Harlan Haskins", "Punctual.swift", "## Punctual.swift\n\nPunctual.swift is a set of extensions to `NSDate`, `Int`, `NSTimeInterval`, `NSCalendar`, and `NSDateComponents`.\n```rust\n1.day.until(NSDate())\n```", "In Progress", 4)
+    ,("DuWayne Theroc-Johnson", "Bloodline", "# Bloodline\nA 1-900 hotline for blood deliveries. Uses the `MEAN` stack -- `MongoDB`, `Express.js`, `Angularjs` and `Node.js`. That means this project is **truly** web scale.\n```javascript\nfunction thing() {\n  console.log('hello');\n}\n```", "Completed", 5)
+    ,("Matt Gambogi", "tyle", "TYped Language Evaluator", "In Progress", 6)
+    ]
+
+projectsCSS = toWidget $(luciusFile "frontend/templates/projects/projects.lucius")
+
+-- | The page for a overview of CSH projects.
+getProjectsR :: Handler Html
+getProjectsR = defaultLayout $ do
+    projectsCSS
+    $(whamletFile "frontend/templates/projects/index.hamlet")
+    where panel member name description status = widgetPanel 6 (title name member status) (contentPanel description)
+
+title name member status = [whamlet|
+  <strong>
+      #{name}
+  <span .project-status>
+      #{status}
+  <br />
+  <span .project-author>
+      by
+      <strong>
+          #{member}
+|]
+
+-- TODO handle parse error correctly
+contentPanel :: T.Text -> Widget
+contentPanel description = [whamlet|
+  <div .project-content>
+      ^{either (error . show) id $ markdownToHtml $ Markdown description}
+|]
+
+getProjectR id = defaultLayout $ do
+    projectsCSS
+    panel
+    where fromID = find (\(_, _, _, _, id') -> id == id') projects
+          panel = case fromID of
+                    Nothing -> notFound
+                    Just (member, name, description, status, _) -> widgetPanelOffset 8 2 (title name member status) (contentPanel description)
+
+committees :: [T.Text]
+committees = ["Evaluations", "Financial", "OpComm", "House History", "House Improvements", "Research and Development", "Social", "Chairman"]
+
+projectForm = $(whamletFile "frontend/templates/projects/create.hamlet")
+
+getCreateProjectR = defaultLayout $ do
+    projectsCSS
+    widgetPanelOffset 8 2 [whamlet|New Project|] projectForm

--- a/src/CSH/Eval/Frontend/Widgets.hs
+++ b/src/CSH/Eval/Frontend/Widgets.hs
@@ -1,0 +1,53 @@
+{-|
+Module      : CSH.Eval.Frontend.Widget
+Description : Reusable widgets for use in EvalFrontend pages
+Copyright   : Stephen Demos, Matt Gambogi, Travis Whitaker, Computer Science House 2015
+License     : MIT
+Maintainer  : pvals@csh.rit.edu
+Stability   : Provisional
+Portability : POSIX
+
+Defines the web application layer of Evals
+-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE ViewPatterns      #-}
+
+module CSH.Eval.Frontend.Widgets
+( widgetPanel
+, widgetPanelOffset
+, widgetPanelText
+) where
+
+import qualified Data.Text as T
+
+import CSH.Eval.Frontend.Data
+import Text.Hamlet (hamletFile)
+import Text.Lucius (luciusFile)
+import Text.Blaze  (preEscapedText)
+import Yesod
+
+-- | A helper function to convert integers to text, to make templates that use
+-- Integer arguments more readable.
+toText :: Integer -> T.Text
+toText = T.pack . show
+
+-- | A basic widget for a panel
+widgetPanel :: Integer -- horizontal size of the panel
+            -> Widget  -- widget for the title of the panel
+            -> Widget  -- widget for the body of the panel
+            -> Widget
+widgetPanel mdsize = widgetPanelOffset mdsize 0
+
+widgetPanelOffset :: Integer -> Integer -> Widget -> Widget -> Widget
+widgetPanelOffset mdsize mdoffset title body = $(whamletFile "frontend/templates/widgets/panel.hamlet")
+
+-- | A basic widget for a panel that takes text as arguments instead of widgets
+widgetPanelText :: Integer -- horizontal size of the panel
+                -> T.Text  -- html for the title of the panel
+                -> T.Text  -- html for the body of the panel
+                -> Widget
+widgetPanelText mdsize title body = $(whamletFile "frontend/templates/widgets/panelText.hamlet")


### PR DESCRIPTION
Fixes #69 

All new sections of the site should go in their own haskell file now. 

There is one question, do people think that all of the handler haskell files should go in their own folder under the `frontend` folder? I thought that the paths and modules names would be too long then, but if people think it would be too cluttered, I can change that and add it to this pr. 
