### PR TITLE
stack: use patched yesod-markdown

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "yesod-markdown"]
+	path = yesod-markdown
+	url = git@github.com:robgssp/yesod-markdown.git

--- a/circle.yml
+++ b/circle.yml
@@ -22,4 +22,4 @@ test:
         - cabal exec -- stack test
     post:
         - mkdir $CIRCLE_ARTIFACTS/doc
-        - cabal exec -- stack exec -- haddock -h -o doc `find src -type f`
+        - cabal exec -- stack exec -- haddock -h -o $CIRCLE_ARTIFACTS/doc `find src -type f`

--- a/circle.yml
+++ b/circle.yml
@@ -21,5 +21,5 @@ test:
     override:
         - cabal exec -- stack test
     post:
-        - cabal exec -- stack haddock
-        - cp -r .stack-work/dist/x86_64-linux/Cabal-1.22.2.0/doc/html $CIRCLE_ARTIFACTS/doc
+        - mkdir $CIRCLE_ARTIFACTS/doc
+        - cabal exec -- stack exec -- haddock -h -o doc `find src -type f`

--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,8 @@ dependencies:
     post:
         - echo "create role pvals with password 'circleci';" | psql -U postgres
         - createdb pvals -O pvals
+        - git submodule init
+        - git submodule update
         - cabal exec -- stack build
         - cabal exec -- stack test --only-snapshot
         - echo 'circleci' > cabal exec -- stack exec -- csh-eval-db-init localhost 5432 pvals pvals

--- a/csh-eval.cabal
+++ b/csh-eval.cabal
@@ -34,7 +34,7 @@ executable csh-eval
                        ,uuid                >=1.3.10   && <1.3.11
                        ,text                >=1.2      && <1.3
                        ,blaze-markup        >=0.7      && <0.8
-                       ,yesod-markdown      >=0.9.4
+                       ,yesod-markdown      >=0.9.5
   hs-source-dirs:      src
   default-extensions:  OverloadedStrings
   default-language:    Haskell2010
@@ -77,7 +77,7 @@ library
                       ,uuid                 >=1.3.10   && <1.3.11
                       ,shakespeare          >=2.0.5    && <2.0.6
                       ,blaze-markup         >=0.7      && <0.8
-                      ,yesod-markdown       >=0.9.4
+                      ,yesod-markdown       >=0.9.5
   default-language:    Haskell2010
 
 test-suite tests

--- a/src/CSH/Eval/Frontend.hs
+++ b/src/CSH/Eval/Frontend.hs
@@ -146,10 +146,11 @@ title name member status = [whamlet|
           #{member}
 |]
 
+-- TODO handle parse error correctly
 contentPanel :: T.Text -> Widget
 contentPanel description = [whamlet|
   <div .project-content>
-      ^{markdownToHtml $ Markdown description}
+      ^{either (error . show) id $ markdownToHtml $ Markdown description}
 |]
 
 getProjectR id = defaultLayout $ do

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,9 @@
 flags: {}
 packages:
 - '.'
+- location:
+    git: git@github.com:robgssp/yesod-markdown
+    commit: 1860815cf5fe193e9593a9adc7211929e803a7d1
 extra-deps:
 - ldap-client-0.1.0
 resolver: nightly-2015-07-26

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,10 @@
 flags: {}
 packages:
 - '.'
-- location:
-    git: git@github.com:robgssp/yesod-markdown
-    commit: 1860815cf5fe193e9593a9adc7211929e803a7d1
+- 'yesod-markdown'
+# - location:
+#     git: git@github.com:robgssp/yesod-markdown
+#     commit: 1860815cf5fe193e9593a9adc7211929e803a7d1
 extra-deps:
 - ldap-client-0.1.0
 resolver: nightly-2015-07-26


### PR DESCRIPTION
yesod-markdown didn't support newer pandoc; it does now.
