### PR TITLE
csh-eval command line args

### DIFF
--- a/csh-eval.cabal
+++ b/csh-eval.cabal
@@ -23,6 +23,7 @@ executable csh-eval
                       ,csh-eval
                       ,hasql                >=0.7.3    && <0.7.4
                       ,hasql-postgres       >=0.10.3   && <0.10.4
+                      ,optparse-applicative
                       ,safe                 >=0.3.9    && <0.3.10
                       ,servant              >=0.4      && <0.5
                       ,servant-server       >=0.4      && <0.5

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,11 +1,46 @@
-import Network.Wai.Handler.Warp (defaultSettings, setPort)
+import Network.Wai.Handler.Warp (defaultSettings
+                                , setPort
+                                , Port
+                                , runEnv)
 import Network.Wai.Handler.WarpTLS (runTLS, tlsSettings)
 import CSH.Eval.Routes (evalAPI)
 import CSH.Eval.Frontend (evalFrontend)
+import Options.Applicative
+
+data ServerOpts = ServerOpts { port :: Port
+                             , withTLS :: Bool
+                             }
+
+runWithOptions :: ServerOpts -> IO ()
+runWithOptions opts = evalFrontend
+                  >>= if withTLS opts
+                      then runTLS (tlsSettings "server.crt" "server.key")
+                                  (setPort (port opts) defaultSettings)
+                      else runEnv (port opts)
+
 
 -- | Main function for running the Evaluations Database website
 -- This runs the evaluations databse frontend defined in "CSH.Eval.Frontend"
 -- using warp, running on the port defined the the PORT environment variable
 -- (defaulting to running on port 8000)
-main = evalFrontend >>= runTLS (tlsSettings "server.crt" "server.key")
-                               (setPort 8000 defaultSettings)
+main = execParser opts >>= runWithOptions 
+   where
+     parser = ServerOpts <$> optPort
+                         <*> optWithTLS
+     opts = info parser mempty
+
+optPort :: Parser Port
+optPort = option auto
+        (  long "port"
+        <> short 'p'
+        <> value 8000
+        <> metavar "K"
+        <> help "Run site on port K"
+        )
+
+optWithTLS :: Parser Bool
+optWithTLS = switch
+           (  long "tls_support"
+           <> short 's'
+           <> help "Enable TLS support."
+           )


### PR DESCRIPTION
Added option to run with or without TLS support
Added option to specify port (still defaults to 8000)
Bash/Zsh tab completion for free!
Also help text.
