### PR TITLE
fixed ssl configuration setting

### DIFF
--- a/src/CSH/Eval/Config.hs
+++ b/src/CSH/Eval/Config.hs
@@ -12,7 +12,17 @@ Provides functionality for reading config values
 module CSH.Eval.Config
 ( evalConfig
 , module Data.Configurator
+, Command (..)
+, ServerCmd (..)
 ) where
 import Data.Configurator
+import Network.Wai.Handler.Warp (Port)
+
+data Command = Members ServerCmd
+             | Intro ServerCmd
+
+data ServerCmd = ServerCmd { withTLS :: Bool
+                           , port    :: Port
+                           }
 
 evalConfig = load [Required "config/csh-eval.rc"]

--- a/src/CSH/Eval/Frontend.hs
+++ b/src/CSH/Eval/Frontend.hs
@@ -24,6 +24,7 @@ import CSH.Eval.Frontend.Data
 import CSH.Eval.Frontend.Projects
 import CSH.Eval.Frontend.Evals
 import CSH.Eval.Frontend.Home
+import CSH.Eval.Config
 import Text.Hamlet (hamletFile)
 import Text.Lucius (luciusFile)
 import Yesod
@@ -32,7 +33,7 @@ import Yesod.Static
 mkYesodDispatch "EvalFrontend" resourcesEvalFrontend
 
 -- | Defines the WAI Application for the eval Yesod app
-evalFrontend :: IO Application
-evalFrontend = do
+evalFrontend :: ServerCmd -> IO Application
+evalFrontend config = do
     s <- static "frontend/static"
-    toWaiApp $ EvalFrontend s
+    toWaiApp $ EvalFrontend s config

--- a/src/CSH/Eval/Frontend/Home.hs
+++ b/src/CSH/Eval/Frontend/Home.hs
@@ -37,7 +37,7 @@ import Yesod
 getHomeR :: Handler Html
 getHomeR = do
            req <- waiRequest
-           let usr = fromJust $ L.lookup "X-WEBAUTH-USER" (requestHeaders req)
+           let usr = fromMaybe "" (L.lookup "X-WEBAUTH-USER" (requestHeaders req))
            name <- fmap B.unpack (liftIO $ lookupCN usr)
            let showIntroF = True
            let showSpringF = True

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -5,19 +5,13 @@ import Network.Wai.Handler.Warp (defaultSettings
 import Network.Wai.Handler.WarpTLS (runTLS, tlsSettings)
 import CSH.Eval.Routes (evalAPI)
 import CSH.Eval.Frontend (evalFrontend)
+import CSH.Eval.Config (Command (..), ServerCmd (..))
 import Options.Applicative
 import Text.PrettyPrint.ANSI.Leijen (text)
 
-data Command = Members ServerCmd
-             | Intro ServerCmd
-
-data ServerCmd = ServerCmd { withTLS :: Bool
-                           , port    :: Port
-                           }
-
 runWithOptions :: Command -> IO ()
 runWithOptions (Members opts) = putStrLn cshlogo
-                             >> evalFrontend
+                             >> evalFrontend opts
                             >>= if withTLS opts
                                 then runTLS (tlsSettings "server.crt" "server.key")
                                             (setPort (port opts) defaultSettings)


### PR DESCRIPTION
now csh-eval respects the --tls flag completely, and people who aren't running it on fangorn can use it without a reverse proxy from san. 
