### PR TITLE
Added documentation generation back to circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,12 +14,13 @@ dependencies:
     override:
         - echo "create role pvals with password 'circleci';" | psql -U postgres
         - createdb pvals -O pvals
-        - stack build
+        - stack build --haddock
         - stack test --only-snapshot
         - echo 'circleci' | stack exec -- csh-eval initdb localhost 5432 pvals pvals
+    post:
+        - mkdir $CIRCLE_ARTIFACTS/doc
+        - cp -r .stack-work/dist/x86_64-linux/Cabal-1.22.4.0/doc $CIRCLE_ARTIFACTS/doc
 
 test:
     override:
         - stack test
-    post:
-        - mkdir $CIRCLE_ARTIFACTS/doc

--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,7 @@ dependencies:
         - tar -xvf stack-0.1.6.0-linux-x86_64.tar.gz
         - sudo cp stack-0.1.6.0-linux-x86_64/stack /usr/bin/stack
         - stack setup
+        - stack install hscolour
     override:
         - echo "create role pvals with password 'circleci';" | psql -U postgres
         - createdb pvals -O pvals

--- a/src/CSH/Eval/Cacheable/Prim.hs
+++ b/src/CSH/Eval/Cacheable/Prim.hs
@@ -132,18 +132,17 @@ hitRecordFallback = ((flip fromMaybe . ((liftIO . readMVar) <$>)) .) . M.lookup
 --   expected to return zero or one result(s). This function does not return
 --   into the 'Maybe' monad; it is named for 'maybeEx' and must be called with
 --   a statement obeying the assumptions 'maybeEx' makes.
-liftMaybeQ :: CxRow Postgres t
-           -- ^ SQL Statement to execute. The statement must return exactly
-           --   zero or one record(s).
-           => Stmt Postgres
+liftMaybeQ :: CxRow Postgres t => Stmt Postgres
            -- ^ SQL Statement to execute. The statement must return exactly
            --   zero or one record(s).
            -> CacheError
-           -- ^ The error to return if the statement provides no results.
+           -- ^ SQL Statement to execute. The statement must return exactly
+           --   zero or one record(s).
            -> (t -> r)
+           -- ^ The error to return if the statement provides no results.
+           -> Cacheable r
            -- ^ Function from the record tuple to the thing you actually
            --   want.
-           -> Cacheable r
 liftMaybeQ s dbe fr c = do
     r <- session (pool c) (tx defTxMode (maybeEx s))
     case r of (Left e)         -> left $ HasqlError e


### PR DESCRIPTION
This will move the generated documentation to the circle artifacts, so that Travis can look at the haddock whenever he wants. 
