### PR TITLE
First pass on Cache init from config

### DIFF
--- a/config/csh-eval.rc.example
+++ b/config/csh-eval.rc.example
@@ -20,6 +20,10 @@ db {
     host     = "localhost"
     port     = "db.port"
     database = "db.name"
+    pool {
+        max_con      = 1
+        idle_timeout = 10
+    }
 }
 
 ldap {

--- a/src/CSH/Eval/Cacheable/Prim.hs
+++ b/src/CSH/Eval/Cacheable/Prim.hs
@@ -56,7 +56,8 @@ import Hasql
 import Hasql.Postgres
 
 import CSH.Eval.Model
-
+import CSH.Eval.Config
+--
 -- | Initialize a 'Cache', including the enclosed 'Pool'.
 initCache :: Settings
           -> PoolSettings
@@ -104,6 +105,14 @@ initCache cs ps = Cache
              <*>  newIDCache
              <*>  acquirePool cs ps
                   where newIDCache = (liftIO . newMVar) M.empty
+
+-- | Initialize a 'Cache' with settings derived from the config
+initCacheFromConfig :: IO Cache
+initCacheFromConfig = do
+    cfg <- evalConfig
+    cxSets <- cxCfgSettings cfg
+    poolSets <- poolCfgSettings cfg
+    initCache cxSets poolSets
 
 -- | Release the 'Pool' enclosed in a 'Cache'.
 releaseCache :: Cache -> IO ()

--- a/src/CSH/Eval/Config.hs
+++ b/src/CSH/Eval/Config.hs
@@ -54,13 +54,12 @@ evalConfig = lookupEnv "CSH_EVAL_CONFIG"
 
 -- | Derive hasql postgres connection settings from configuration.
 cxCfgSettings :: Config -> IO Settings
-cxCfgSettings cfg = do
-    host     <- (lookupDefault "localhost" cfg "db.host")
-    port     <- (lookupDefault 5432 cfg "db.port")
-    user     <- (lookupDefault "" cfg "db.user")
-    password <- (lookupDefault "" cfg "db.password")
-    dbname   <- (lookupDefault "" cfg "db.dbname")
-    pure (ParamSettings host port user password dbname)
+cxCfgSettings cfg = ParamSettings
+                <$> (lookupDefault "localhost" cfg "db.host")
+                <*> (lookupDefault 5432 cfg "db.port")
+                <*> (lookupDefault "" cfg "db.user")
+                <*> (lookupDefault "" cfg "db.password")
+                <*> (lookupDefault "" cfg "db.dbname")
 
 -- | Derive hasql pool settings from configuration.
 poolCfgSettings :: Config -> IO PoolSettings

--- a/src/CSH/Eval/Config.hs
+++ b/src/CSH/Eval/Config.hs
@@ -11,6 +11,8 @@ Provides functionality for reading config values.
 -}
 module CSH.Eval.Config (
     evalConfig
+  , cxCfgSettings
+  , poolCfgSettings
   , module Data.Configurator
   , Command (..)
   , ServerCmd (..)
@@ -20,22 +22,54 @@ module CSH.Eval.Config (
 import Data.Configurator
 import Data.Configurator.Types
 import Data.Word (Word16)
+import Hasql
+import Hasql.Postgres
+import System.Environment
 import qualified Data.ByteString.Char8 as C
 
-data Command = Members ServerCmd
-             | Intro ServerCmd
-             | InitDB DBInitCmd
+-- | Toplevel 'csh-eval' command configuration type.
+data Command = Members ServerCmd -- ^ Members only site configuration type
+             | Intro ServerCmd   -- ^ Freshman site configuration type
+             | InitDB DBInitCmd  -- ^ DB initialization command configuation type
 
-data ServerCmd = ServerCmd { withTLS :: Bool
-                           , port    :: Int
+-- | Configuation type for launching either site
+data ServerCmd = ServerCmd { withTLS :: Bool -- ^ Launch with TLS support
+                           , port    :: Int  -- ^ Which port to launch on
                            }
 
+-- | Configuration type for running the db initialization script
 data DBInitCmd = DBInitCmd
-                { dbHost :: C.ByteString
-                , dbPort :: Word16
-                , dbUser :: C.ByteString
-                , dbName :: C.ByteString
+                { dbHost :: C.ByteString -- ^ Database hostname
+                , dbPort :: Word16       -- ^ Database port
+                , dbUser :: C.ByteString -- ^ Database username
+                , dbName :: C.ByteString -- ^ Database name
                 }
 
+-- | Load a config from the path given by the 'CSH_EVAL_CONFIG' environment
+--   variable, or default to 'config/csh-eval.rc'
 evalConfig :: IO Config
-evalConfig = load [Required "config/csh-eval.rc"]
+evalConfig = lookupEnv "CSH_EVAL_CONFIG"
+         >>= maybe (load [Required "config/csh-eval.rc"])
+                   (\x -> load [Required x])
+
+-- | Derive hasql postgres connection settings from configuration.
+cxCfgSettings :: Config -> IO Settings
+cxCfgSettings cfg = do
+    host     <- (lookupDefault "localhost" cfg "db.host")
+    port     <- (lookupDefault 5432 cfg "db.port")
+    user     <- (lookupDefault "" cfg "db.user")
+    password <- (lookupDefault "" cfg "db.password")
+    dbname   <- (lookupDefault "" cfg "db.dbname")
+    pure (ParamSettings host port user password dbname)
+
+-- | Derive hasql pool settings from configuration.
+poolCfgSettings :: Config -> IO PoolSettings
+poolCfgSettings cfg = do
+    max_con <- (lookupDefault 1 cfg "db.pool.max_con")
+    idle_timeout <- (lookupDefault 10 cfg "db.pool.idle_timeout")
+    case poolSettings max_con idle_timeout of
+        Just x -> pure x
+        Nothing -> fail ("Bad pool settings config:\n  db.pool.max_con = "
+                       ++ (show max_con)
+                       ++ "\n  db.pool.idle_timeout: "
+                       ++ (show idle_timeout))


### PR DESCRIPTION
- Added three functions for initalizing a Cache from config data
- Config path may now be configured by setting the `CSH_EVAL_CONFIG`
  environment variable
- Added documentation to CSH.Eval.Config module
