### PR TITLE
removed package version constraints

### DIFF
--- a/csh-eval.cabal
+++ b/csh-eval.cabal
@@ -1,96 +1,96 @@
 -- csh-eval.cabal
 
-name:                  csh-eval
-version:               0.1.0.0
-synopsis:              REPL for PEOPLE
-description:           REPL for PEOPLE
-homepage:              https://github.com/ComputerScienceHouse/csh-eval
-license:               MIT
-license-file:          LICENSE
-author:                Matt Gambogi, Stephen Demos, Travis Whitaker
-maintainer:            pvals@csh.rit.edu
-copyright:             Matt Gambogi, Stephen Demos, Travis Whitaker, Computer Science House 2015
-category:              Control
-build-type:            Simple
-extra-source-files:    README.md
-cabal-version:         >=1.10
+name:                 csh-eval
+version:              0.1.0.0
+synopsis:             REPL for PEOPLE
+description:          REPL for PEOPLE
+homepage:             https://github.com/ComputerScienceHouse/csh-eval
+license:              MIT
+license-file:         LICENSE
+author:               Matt Gambogi, Stephen Demos, Travis Whitaker
+maintainer:           pvals@csh.rit.edu
+copyright:            Matt Gambogi, Stephen Demos, Travis Whitaker, Computer Science House 2015
+category:             Control
+build-type:           Simple
+extra-source-files:   README.md
+cabal-version:        >=1.10
 
 executable csh-eval
   main-is:            Main.hs
-  build-depends:        ansi-wl-pprint
-                      , base                 >=4.7      && <4.9
-                      , optparse-applicative >=0.11     && <0.12
-                      , warp                 >=3.1      && <3.2
-                      , warp-tls             >=3.1      && <3.2
-                      , csh-eval
+  build-depends:      ansi-wl-pprint
+                    , base
+                    , optparse-applicative
+                    , warp
+                    , warp-tls
+                    , csh-eval
   hs-source-dirs:     app
   default-extensions: OverloadedStrings
   default-language:   Haskell2010
 
 library
-  exposed-modules:      CSH.Eval.Cacheable.Prim
-                      , CSH.Eval.Cacheable.Fetch
-                      , CSH.Eval.Cacheable.Make
-                      , CSH.Eval.Config
-                      , CSH.Eval.DB.Init
-                      , CSH.Eval.DB.Schema
-                      , CSH.Eval.DB.Statements
-                      , CSH.Eval.Frontend
-                      , CSH.Eval.Frontend.Data
-                      , CSH.Eval.Frontend.Evals
-                      , CSH.Eval.Frontend.Home
-                      , CSH.Eval.Frontend.Members
-                      , CSH.Eval.Frontend.ProfilePhoto
-                      , CSH.Eval.Frontend.Projects
-                      , CSH.Eval.Frontend.Attendance
-                      , CSH.Eval.Frontend.Widgets
-                      , CSH.Eval.Routes
-                      , CSH.Eval.Model
-                      , CSH.LDAP
+  exposed-modules:    CSH.Eval.Cacheable.Prim
+                    , CSH.Eval.Cacheable.Fetch
+                    , CSH.Eval.Cacheable.Make
+                    , CSH.Eval.Config
+                    , CSH.Eval.DB.Init
+                    , CSH.Eval.DB.Schema
+                    , CSH.Eval.DB.Statements
+                    , CSH.Eval.Frontend
+                    , CSH.Eval.Frontend.Data
+                    , CSH.Eval.Frontend.Evals
+                    , CSH.Eval.Frontend.Home
+                    , CSH.Eval.Frontend.Members
+                    , CSH.Eval.Frontend.ProfilePhoto
+                    , CSH.Eval.Frontend.Projects
+                    , CSH.Eval.Frontend.Attendance
+                    , CSH.Eval.Frontend.Widgets
+                    , CSH.Eval.Routes
+                    , CSH.Eval.Model
+                    , CSH.LDAP
   hs-source-dirs:     src
-  build-depends:        base                 >=4.7      && <4.9
-                      , blaze-markup         >=0.7      && <0.8
-                      , containers           >=0.5      && <0.6
-                      , either               >=4.4      && <4.5
-                      , transformers         >=0.4      && <0.5
-                      , containers           >=0.5      && <0.6
-                      , either               >=4.4      && <4.5
-                      , transformers         >=0.4      && <0.5
-                      , bytestring           >=0.10     && <0.11
-                      , configurator         >=0.3      && <0.4
-                      , cryptohash           >=0.11     && <0.12
-                      , hasql                >=0.7      && <0.8
-                      , hasql-postgres       >=0.10     && <0.11
-                      , hslogger             >=1.2      && <1.3
-                      , http-types           >=0.8      && <0.9
-                      , ldap-client          >=0.1      && <0.2
-                      , monad-control        >=1.0      && <1.1
-                      , optparse-applicative >=0.11     && <0.12
-                      , safe                 >=0.3      && <0.4
-                      , servant              >=0.4      && <0.5
-                      , servant-server       >=0.4      && <0.5
-                      , shakespeare          >=2.0      && <2.1
-                      , text                 >=1.2      && <1.3
-                      , time                 >=1.5      && <1.6
-                      , uuid                 >=1.3      && <1.4
-                      , wai                  >=3.0      && <3.1
-                      , yesod                >=1.4      && <1.5
-                      , yesod-markdown       >=0.10     && <0.11
-                      , yesod-static         >=1.5      && <1.6
+  build-depends:      base
+                    , blaze-markup
+                    , containers
+                    , either
+                    , transformers
+                    , containers
+                    , either
+                    , transformers
+                    , bytestring
+                    , configurator
+                    , cryptohash
+                    , hasql
+                    , hasql-postgres
+                    , hslogger
+                    , http-types
+                    , ldap-client
+                    , monad-control
+                    , optparse-applicative
+                    , safe
+                    , servant
+                    , servant-server
+                    , shakespeare
+                    , text
+                    , time
+                    , uuid
+                    , wai
+                    , yesod
+                    , yesod-markdown
+                    , yesod-static
   default-language:   Haskell2010
   default-extensions: OverloadedStrings
                     , TemplateHaskell
 
 test-suite tests
-  hs-source-dirs:       test
-  main-is:              Tests.hs
-  build-depends:        base                 >=4.7      && <4.9
-                      , doctest              >=0.10     && <0.11
-                      , quickcheck-instances >=0.3      && <0.4
-                      , safe                 >=0.3      && <0.4
-                      , tasty                >=0.10     && <0.11
-                      , tasty-hunit          >=0.9      && <0.10
-                      , tasty-quickcheck     >=0.8      && <0.9
+  hs-source-dirs:     test
+  main-is:            Tests.hs
+  build-depends:      base
+                    , doctest
+                    , quickcheck-instances
+                    , safe
+                    , tasty
+                    , tasty-hunit
+                    , tasty-quickcheck
   ghc-options:        -Wall
   default-extensions: OverloadedStrings
   default-language:   Haskell2010


### PR DESCRIPTION
stack guarantees packages in a resolver working together, and there is only one version of each package connected to each resolver, so this removes the pain from updating. Well, the manual version updating pain. The rest of the pain is still there. 
